### PR TITLE
Handle null config data.

### DIFF
--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
@@ -11,7 +11,6 @@ import com.electronwill.nightconfig.toml.TomlFormat;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.loading.StringUtils;
-import org.jetbrains.annotations.Nullable;
 import xyz.bluspring.kilt.loader.WrappedFabricModContainer;
 
 import java.io.ByteArrayInputStream;
@@ -97,14 +96,17 @@ public class ModConfig
         return ((CommentedFileConfig)this.configData).getNioPath();
     }
 
-    public void acceptSyncedConfig(byte @Nullable [] bytes) {
-        if (bytes != null) {
-            setConfigData(TomlFormat.instance().createParser().parse(new ByteArrayInputStream(bytes)));
-            fireEvent(IConfigEvent.reloading(this));
-        } else {
+    public void acceptSyncedConfig(byte[] bytes) {
+        // Kilt: Handle null config data, because Forge Config API Port requires us to.
+        if (bytes == null) {
             setConfigData(null);
             fireEvent(IConfigEvent.unloading(this));
+            return;
         }
+
+        // original code
+        setConfigData(TomlFormat.instance().createParser().parse(new ByteArrayInputStream(bytes)));
+        fireEvent(IConfigEvent.reloading(this));
     }
 
     public enum Type {

--- a/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
+++ b/fmlcore/src/main/java/net/minecraftforge/fml/config/ModConfig.java
@@ -11,6 +11,7 @@ import com.electronwill.nightconfig.toml.TomlFormat;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.loading.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import xyz.bluspring.kilt.loader.WrappedFabricModContainer;
 
 import java.io.ByteArrayInputStream;
@@ -96,9 +97,14 @@ public class ModConfig
         return ((CommentedFileConfig)this.configData).getNioPath();
     }
 
-    public void acceptSyncedConfig(byte[] bytes) {
-        setConfigData(TomlFormat.instance().createParser().parse(new ByteArrayInputStream(bytes)));
-        fireEvent(IConfigEvent.reloading(this));
+    public void acceptSyncedConfig(byte @Nullable [] bytes) {
+        if (bytes != null) {
+            setConfigData(TomlFormat.instance().createParser().parse(new ByteArrayInputStream(bytes)));
+            fireEvent(IConfigEvent.reloading(this));
+        } else {
+            setConfigData(null);
+            fireEvent(IConfigEvent.unloading(this));
+        }
     }
 
     public enum Type {


### PR DESCRIPTION
Quick fix for https://github.com/KiltMC/Kilt/issues/676
Forge Config API port seems to send null values to ModConfig::acceptSyncedConfig to indicate that the config should be unloaded ([see the source code](https://github.com/Fuzss/forgeconfigapiport/blob/1.20.1/Common/src/main/java/net/minecraftforge/fml/config/ModConfig.java#L96)). This patch basically just copies that behaviour. The reason the bug disappeared when adding Forge Config API port is that it no longer unloads the config on world exit in version 8.0.3 onwards, while Dungeon Now Loading bundles 8.0.0.

Why is the Nullable annotation between the byte and the square brackets, you ask? Answer: IntelliJ preferred it that way.